### PR TITLE
enhance handling inconsistent tabularInput keys + test

### DIFF
--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -42,18 +42,10 @@ class CsvOutput(FileOutput):
                 self._writer.writeheader()
 
             if to_csv.keys() != self._fieldnames:
-                # self._warn('Inconsistent TabularInput keys detected. '
-                #            'CsvOutput keys: {}. '
-                #            'TabularInput keys: {}. '
-                #            'Did you change key sets after your first '
-                #            'logger.log(TabularInput)?'.format(
-                #                set(self._fieldnames), set(to_csv.keys())))
-
-                # new field appear
                 new_fields = set(to_csv.keys()).union(set(self._fieldnames))
                 if len(new_fields) > len(self._fieldnames):
                     self._fieldnames = new_fields
-                    self._file_sections.append(self._file_name + f'_{len(self._file_sections)}')
+                    self._file_sections.append(self._file_name + '_{}'.format(len(self._file_sections)))
                     self._log_file = open(self._file_sections[-1], 'w')
                     self._init_writer()
                     self._writer.writeheader()
@@ -69,7 +61,6 @@ class CsvOutput(FileOutput):
         super().dump()
         if len(self._file_sections) > 1:
             self._merge_file_sections()
-            self._file_sections = self._file_sections[:1]
 
     def _merge_file_sections(self):
         if len(self._file_sections) == 1:
@@ -84,12 +75,13 @@ class CsvOutput(FileOutput):
                 for r in reader:
                     self._writer.writerow(r)
             os.remove(sec_file_name)
+        self._file_sections = self._file_sections[:1]
 
     def _init_writer(self):
         self._writer = csv.DictWriter(
             self._log_file,
-            fieldnames=sorted(list(self._fieldnames)),
-            extrasaction='ignore')
+            fieldnames=sorted(list(self._fieldnames))
+        )
 
     def _warn(self, msg):
         """Warns the user using warnings.warn.

--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -88,7 +88,7 @@ class CsvOutput(FileOutput):
     def _init_writer(self):
         self._writer = csv.DictWriter(
             self._log_file,
-            fieldnames=self._fieldnames,
+            fieldnames=sorted(list(self._fieldnames)),
             extrasaction='ignore')
 
     def _warn(self, msg):

--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -1,4 +1,5 @@
 """A `dowel.logger.LogOutput` for CSV files."""
+import os
 import csv
 import warnings
 
@@ -15,6 +16,8 @@ class CsvOutput(FileOutput):
 
     def __init__(self, file_name):
         super().__init__(file_name)
+        self._file_name = file_name
+        self._file_sections = [file_name+'_0']
         self._writer = None
         self._fieldnames = None
         self._warned_once = set()
@@ -35,19 +38,25 @@ class CsvOutput(FileOutput):
 
             if not self._writer:
                 self._fieldnames = set(to_csv.keys())
-                self._writer = csv.DictWriter(
-                    self._log_file,
-                    fieldnames=self._fieldnames,
-                    extrasaction='ignore')
+                self._init_writer()
                 self._writer.writeheader()
 
             if to_csv.keys() != self._fieldnames:
-                self._warn('Inconsistent TabularInput keys detected. '
-                           'CsvOutput keys: {}. '
-                           'TabularInput keys: {}. '
-                           'Did you change key sets after your first '
-                           'logger.log(TabularInput)?'.format(
-                               set(self._fieldnames), set(to_csv.keys())))
+                # self._warn('Inconsistent TabularInput keys detected. '
+                #            'CsvOutput keys: {}. '
+                #            'TabularInput keys: {}. '
+                #            'Did you change key sets after your first '
+                #            'logger.log(TabularInput)?'.format(
+                #                set(self._fieldnames), set(to_csv.keys())))
+
+                # new field appear
+                new_fields = set(to_csv.keys()).union(set(self._fieldnames))
+                if len(new_fields) > len(self._fieldnames):
+                    self._fieldnames = new_fields
+                    self._file_sections.append(self._file_name + f'_{len(self._file_sections)}')
+                    self._log_file = open(self._file_sections[-1], 'w')
+                    self._init_writer()
+                    self._writer.writeheader()
 
             self._writer.writerow(to_csv)
 
@@ -55,6 +64,32 @@ class CsvOutput(FileOutput):
                 data.mark(k)
         else:
             raise ValueError('Unacceptable type.')
+
+    def dump(self, step=None):
+        super().dump()
+        if len(self._file_sections) > 1:
+            self._merge_file_sections()
+            self._file_sections = self._file_sections[:1]
+
+    def _merge_file_sections(self):
+        if len(self._file_sections) == 1:
+            return
+        os.rename(self._file_name, self._file_sections[0])
+        self._log_file = open(self._file_name, 'w')
+        self._init_writer()
+        self._writer.writeheader()
+        for sec_file_name in self._file_sections:
+            with open(sec_file_name)as f:
+                reader = csv.DictReader(f)
+                for r in reader:
+                    self._writer.writerow(r)
+            os.remove(sec_file_name)
+
+    def _init_writer(self):
+        self._writer = csv.DictWriter(
+            self._log_file,
+            fieldnames=self._fieldnames,
+            extrasaction='ignore')
 
     def _warn(self, msg):
         """Warns the user using warnings.warn.

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -35,26 +35,47 @@ class TestCsvOutput:
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 
-    def test_record_inconsistent(self):
-        foo = 1
-        bar = 10
-        self.tabular.record('foo', foo)
-        self.csv_output.record(self.tabular)
-        self.tabular.record('foo', foo * 2)
-        self.tabular.record('bar', bar * 2)
+    # conflicting functionality
+    # def test_record_inconsistent(self):
+    #     foo = 1
+    #     bar = 10
+    #     self.tabular.record('foo', foo)
+    #     self.csv_output.record(self.tabular)
+    #     self.tabular.record('foo', foo * 2)
+    #     self.tabular.record('bar', bar * 2)
+    #
+    #     with pytest.warns(CsvOutputWarning):
+    #         self.csv_output.record(self.tabular)
+    #
+    #     # this should not produce a warning, because we only warn once
+    #     self.csv_output.record(self.tabular)
+    #
+    #     self.csv_output.dump()
+    #
+    #     correct = [
+    #         {'foo': str(foo)},
+    #         {'foo': str(foo * 2)},
+    #     ]  # yapf: disable
+    #     self.assert_csv_matches(correct)
 
-        with pytest.warns(CsvOutputWarning):
+    def test_inconsistent_keys(self):
+        for i in range(4):
+            self.tabular.record('itr', i)
+            self.tabular.record('loss', 100.0 / (2 + i))
+
+            # the addition of new data to tabular breaks logging to CSV
+            if i > 1:
+                self.tabular.record('new_data', i)
+
             self.csv_output.record(self.tabular)
-
-        # this should not produce a warning, because we only warn once
-        self.csv_output.record(self.tabular)
-
-        self.csv_output.dump()
+            self.csv_output.dump()
 
         correct = [
-            {'foo': str(foo)},
-            {'foo': str(foo * 2)},
-        ]  # yapf: disable
+            {'itr': str(0), 'loss': str(50.0), 'new_data': ''},
+            {'itr': str(1), 'loss': str(100.0/3.), 'new_data': ''},
+            {'itr': str(2), 'loss': str(25.0), 'new_data': str(2)},
+            {'itr': str(3), 'loss': str(20.0), 'new_data': str(3)},
+        ]
         self.assert_csv_matches(correct)
 
     def test_empty_record(self):

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -35,29 +35,6 @@ class TestCsvOutput:
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 
-    # conflicting functionality
-    # def test_record_inconsistent(self):
-    #     foo = 1
-    #     bar = 10
-    #     self.tabular.record('foo', foo)
-    #     self.csv_output.record(self.tabular)
-    #     self.tabular.record('foo', foo * 2)
-    #     self.tabular.record('bar', bar * 2)
-    #
-    #     with pytest.warns(CsvOutputWarning):
-    #         self.csv_output.record(self.tabular)
-    #
-    #     # this should not produce a warning, because we only warn once
-    #     self.csv_output.record(self.tabular)
-    #
-    #     self.csv_output.dump()
-    #
-    #     correct = [
-    #         {'foo': str(foo)},
-    #         {'foo': str(foo * 2)},
-    #     ]  # yapf: disable
-    #     self.assert_csv_matches(correct)
-
     def test_inconsistent_keys(self):
         for i in range(4):
             self.tabular.record('itr', i)


### PR DESCRIPTION
Enhanced by create a new file when meet new field names (```record()``` is called), and merge them when ```dump()``` is called. 

The idea is try to simplify the ```record()``` step, which might be frequently called. It benefits the situation when ```dump()``` is called every training epoch/branch, while ```record()``` is called for every training entry. 

"File sections" is a "redundant" design that can support more customized situations in manual logging. It provides some forward compatibility (file might be splited in different sections for other reasons and needs merge afterwards), while not reduce the efficiency.

https://github.com/rlworkgroup/dowel/issues/45
@avnishn
@zequnyu